### PR TITLE
CRAYSAT-1456: Add tasks to set file permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2022-06-28
+
+### Added
+- Added Ansible tasks to the sat-ncn configuration which enforce consistent
+  permissions on the SAT configuration file and token directory.
+
 ## [1.2.4] - 2022-06-24
 
 ### Changed

--- a/ansible/roles/sat-ncn/tasks/main.yml
+++ b/ansible/roles/sat-ncn/tasks/main.yml
@@ -47,3 +47,14 @@
     disable_recommends: no
     force: yes
     update_cache: yes
+
+- name: "Ensure configuration file has 0600 permissions"
+  file:
+    path: "/root/.config/sat/sat.toml"
+    mode: 0600
+
+- name: "Ensure tokens directory has 0700 permissions"
+  file:
+    path: "/root/.config/sat/tokens"
+    state: "directory"
+    mode: 0700


### PR DESCRIPTION
## Summary and Scope

This change adds Ansible tasks to the install play which sets the
permissions on the `/root/.config/sat/tokens/` directory and the
`/root/.config/sat/sat.toml` file such that they are only readable and
traversable to the owner (i.e. root).

## Issues and Related PRs

* Resolves [CRAYSAT-1456](https://jira-pro.its.hpecorp.net:8443/browse/CRAYSAT-1456)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `baldar-ncn-m002`

### Test description:

Run CFS configuration using updated version of the configuration plays.

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

