### PR TITLE
CRAYSAT-1417: Update SAT ansible plays to install docs-sat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2022-06-30
+
+### Added
+- Added the installation of the docs-sat package.
+
 ## [1.3.0] - 2022-06-28
 
 ### Added

--- a/ansible/roles/sat-ncn/defaults/main.yml
+++ b/ansible/roles/sat-ncn/defaults/main.yml
@@ -30,3 +30,7 @@ sat_repos:
     # Value replaced by runBuildPrep.sh
     disable_gpg_check: @disable_gpg_check@
     disable_repo_gpg_check: yes
+
+sat_packages:
+  - cray-sat-podman
+  - docs-sat

--- a/ansible/roles/sat-ncn/tasks/main.yml
+++ b/ansible/roles/sat-ncn/tasks/main.yml
@@ -40,13 +40,14 @@
   when: item.disable_repo_gpg_check and not item.disable_gpg_check
   loop: "{{ sat_repos }}"
 
-- name: Ensure cray-sat-podman is installed
+- name: Ensure SAT packages are installed
   zypper:
-    name: cray-sat-podman
+    name: "{{ item }}"
     state: latest
     disable_recommends: no
     force: yes
     update_cache: yes
+  loop: "{{ sat_packages }}"
 
 - name: "Ensure configuration file has 0600 permissions"
   file:


### PR DESCRIPTION
* Modify the task that installs the cray-sat-podman RPM so that
  it runs in a loop and installs multiple RPMs.
* Define a new variable, `sat_packages` which is a list of RPMs
  to install. This variable is used with the task that installs
  the RPMs.
* Add change log entry and bump docker image version

Test Description:
* Packaged this branch of sat-cfs-install in the product stream,
  then installed on an internal system.
* I checked the CFS configuration logs and verified both RPMs
  were installed on manager nodes.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable